### PR TITLE
clean up time outputs to only show values we have

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -6,5 +6,51 @@ export function formatNanos(nanos: number): string {
   const justMS = Math.round(ms % 1000);
   const sec = ms / 1000;
   const justSec = Math.round(sec % 1000);
-  return `${justSec}s${justMS}ms${justUS}us${justNS}ns`;
+
+  if (justSec > 0) {
+    // s to ns
+    if (justNS > 0) {
+      return `${justSec}s${justMS}ms${justUS}µs${justNS}ns`;
+    }
+    // s to µs
+    if (justNS > 0) {
+      return `${justSec}s${justMS}ms${justUS}µs`;
+    }
+    // s to ms
+    if (justMS > 0) {
+      return `${justSec}s${justMS}ms`;
+    }
+    // s only
+    return `${justSec}s`;
+  }
+
+  if (justMS > 0) {
+    // ms to ns
+    if (justNS > 0) {
+      return `${justMS}ms${justUS}µs${justNS}ns`;
+    }
+    // ms to µs
+    if (justNS > 0) {
+      return `${justMS}ms${justUS}µs`;
+    }
+    // ms only
+    return `${justMS}ms`;
+  }
+
+  if (justUS > 0) {
+    // µs to ns
+    if (justNS > 0) {
+      return `${justUS}µs${justNS}ns`;
+    }
+    // µs only
+    return `${justUS}µs`;
+  }
+
+  // ns only
+  if (justNS > 0) {
+    return `${justNS}ns`;
+  }
+
+  // The default value for 0 is 0µs.
+  return `0µs`;
 }


### PR DESCRIPTION
So if there is only a single time unit, says s, we will only show that.
If there is a span, say from ms to ns, we will also display the middle ones, in
this case µs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/dist-trace-viewer/17)
<!-- Reviewable:end -->
