### PR TITLE
get tags and node IDs working

### DIFF
--- a/src/TraceAndSidebar.tsx
+++ b/src/TraceAndSidebar.tsx
@@ -62,6 +62,10 @@ class TraceAndSidebar extends Component<TraceAndSidebarProps, TraceAndSidebarSta
               <th>Duration:</th>
               <td>{formatNanos(span.duration)}</td>
             </tr>
+            <tr>
+              <th>Tag:</th>
+              <td>{span.tag}</td>
+            </tr>
           </tbody>
         </table>
         <h3>Log Messages</h3>

--- a/src/TraceView.tsx
+++ b/src/TraceView.tsx
@@ -110,6 +110,19 @@ function flatten(tree: TraceNode, collapsed: number[]) {
   return output;
 }
 
+function pullNodeIDFromTag(tag: string) {
+  if (tag.length === 0) {
+    return '';
+  }
+  // TODO(bram): use a regex for this instead of this by hand ugliness. And move
+  // this to the tree building instead of here.
+  const firstComma = tag.indexOf(',');
+  if (firstComma > 0) {
+    return tag.substr(1, firstComma - 1);
+  }
+  return tag.substr(1, tag.length - 2);
+}
+
 const MICROSECOND = 1000;
 const MILLISECOND = 1000 * MICROSECOND;
 
@@ -149,14 +162,16 @@ class TraceView extends Component<TraceViewProps> {
           const isCollapsed = _.includes(collapsedSpanIDs, span.spanID);
           const timeLabel = formatNanos(span.duration);
           const isLeaf = span.children.length === 0;
+          const nodeID = pullNodeIDFromTag(span.tag);
+          const nodeIDDisplay = nodeID ? ': ' + nodeID : '';
           const label = isLeaf
-            ? `${timeLabel} : ${span.operation}`
+            ? `${timeLabel} : ${span.operation} ${nodeIDDisplay}`
             : isCollapsed
-              ? `${SIDE_ARROW} ${timeLabel} : ${span.operation} (${numDescendants(span)})`
-              : `${DOWN_ARROW} ${timeLabel} : ${span.operation}`;
+              ? `${SIDE_ARROW} ${timeLabel} : ${span.operation} ${nodeIDDisplay} (${numDescendants(span)})`
+              : `${DOWN_ARROW} ${timeLabel} : ${span.operation} ${nodeIDDisplay}`;
           const startTS = span.timestamp.toMillis();
           const endTS = span.timestamp.toMillis() + span.duration / MILLISECOND;
-          const color = StringToColor(span.operation)
+          const color = StringToColor(span.operation);
           return (
             <g
               key={span.spanID}

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -28,6 +28,9 @@ function rowsToTree(rows: TraceNode[]): TraceNode {
     let cur = _.last(stack);
     if (row.spanID == cur.spanID) {
       cur.messages.push(...row.messages);
+      if ((cur.tag.length == 0) && (row.tag.length > 0)) {
+        cur.tag = row.tag;
+      }
     } else if (row.spanID > cur.spanID) {
       // Normally, this span should be a child of the cur span, but there are
       // cases in which this new span was actually created on a higher span so


### PR DESCRIPTION
The tags are not always on the first span message, but seem to always be the
same for all of the messages.  So just populate the span with the first
non-empty tag.

And then we can extract the node id from the tag.  The code is ugly right now
but we have a time cruch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/dist-trace-viewer/18)
<!-- Reviewable:end -->
